### PR TITLE
Add an option to choose when to colorize output.

### DIFF
--- a/flake8_colors/formatter.py
+++ b/flake8_colors/formatter.py
@@ -33,9 +33,29 @@ class ColorFormatter(base.BaseFormatter):
     version = '0.1.8'
 
     @classmethod
+    def add_options(cls, options):
+        options.add_option(
+            '--color',
+            type='str',
+            default='auto',
+            choices=('auto', 'always', 'never'),
+            help='when to colorize the output; can be "always", "auto" (default) or "never"',
+            parse_from_config=True,
+        )
+
+    @classmethod
     def parse_options(cls, options):
-        # Only use color formatting if invoked interactively
-        if sys.__stdin__.isatty():
+        if options.color == 'always':
+            colorized = True
+        elif options.color == 'never':
+            colorized = False
+        else:  # options.color == 'auto'
+            # Only use color formatting if invoked interactively
+            if sys.stdout.isatty():
+                colorized = True
+            else:
+                colorized = False
+        if colorized:
             options.format = sub(r'\$\{([\w]+)\}', cls._replace, options.format)
         else:
             options.format = 'default'


### PR DESCRIPTION
I use flake8 from Makefiles, and https://github.com/and3rson/flake8-colors/commit/a2b611c4091b60a864299a94c30f40651ddba02b disable colorized output in this case.

This diff add a `--color` option similar to `ls`, `grep` and other commands to force-{enable,disable} colorized output, if needed.

The `default` behaviour is similar to https://github.com/and3rson/flake8-colors/commit/a2b611c4091b60a864299a94c30f40651ddba02b so it should be ok, I suppose.