### PR TITLE
Do not discard custom format when disabling colors

### DIFF
--- a/flake8_colors/formatter.py
+++ b/flake8_colors/formatter.py
@@ -51,14 +51,9 @@ class ColorFormatter(base.BaseFormatter):
             colorized = False
         else:  # options.color == 'auto'
             # Only use color formatting if invoked interactively
-            if sys.stdout.isatty():
-                colorized = True
-            else:
-                colorized = False
-        if colorized:
-            options.format = sub(r'\$\{([\w]+)\}', cls._replace, options.format)
-        else:
-            options.format = 'default'
+            colorized = sys.stdout.isatty()
+        replace_with = cls._replace if colorized else ''
+        options.format = sub(r'\$\{([\w]+)\}', replace_with, options.format)
 
     @classmethod
     def _replace(cls, match):


### PR DESCRIPTION
This fixes #12 by simply replacing the `${...}` placeholders with empty strings instead of resetting the format altogether.
I also took the liberty to simplify the code a bit, since `isatty` already returns a bool.

It would be great if this fix could be released as 0.1.10.